### PR TITLE
Add name to signature field

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ It can be created with either your file's content or your file's url.
 
 Nothing much to say here. It follows Universign's signature field.
 
+You can pass the coordinates of the signature or the name of the field.
+
+If the PDF already contains a named signature field, you can use this parameter instead of giving the coordinates (which will be ignored). If the name of this field does not exist in the document, the given coordinates will be used instead.
+
 ### `Universign::TransactionSigner`
 
 * `success_url` is where your user will be redirected after signing the documents.

--- a/lib/universign/signature_field.rb
+++ b/lib/universign/signature_field.rb
@@ -2,12 +2,14 @@ module Universign
   class SignatureField
     attr_reader :params
 
-    def initialize(coordinate:, page:)
-      @coordinate   = coordinate
+    def initialize(coordinate:, name:, page:)
+      @coordinate   = coordinate || [0, 0]
+      @name         = name
       @page         = page
 
       @params = {
         page: @page,
+        name: @name,
         x:    @coordinate[0],
         y:    @coordinate[1]
       }

--- a/spec/universign/transaction_spec.rb
+++ b/spec/universign/transaction_spec.rb
@@ -8,7 +8,7 @@ describe Universign::Transaction do
       email: 'test@gmail.com',
       # phone_number: "0132456789",
       success_url:  "http://success-url.com/",
-      signature:    Universign::SignatureField.new(coordinate: [20, 20], page: 1)
+      signature:    Universign::SignatureField.new(coordinate: [20, 20], name: 'test', page: 1)
     )
   end
 


### PR DESCRIPTION
Add the name attribute to the `SignatureField` structure.

If the PDF already contains a named signature field, you can use this parameter instead of giving the coordinates (which will be ignored). If the name of this field does not exist in the document, the given coordinates will be used instead.