### PR TITLE
bumping rake and gem version

### DIFF
--- a/lib/universign/version.rb
+++ b/lib/universign/version.rb
@@ -1,3 +1,3 @@
 module Universign
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/ruby_universign.gemspec
+++ b/ruby_universign.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', '>= 4.1'
 
   spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "dotenv", "~> 2.0"
   spec.add_development_dependency "webmock", "~> 3.0"


### PR DESCRIPTION
This PR bump Rake development version to **12.3.3** to fix the security issue CVE-2020-8130  https://github.com/advisories/GHSA-jppv-gw3r-w3q8