### PR TITLE
[450] Added additional checkboxes to "Universign::Document"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.5.2
+-------------------------
+- Added the possibility to add required checkboxes to `Universign::Document`.
+
 v1.5.1
 -------------------------
 - Fix bugs on multi-threads requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v1.5.2
+v1.6.0
 -------------------------
 - Added the possibility to add required checkboxes to `Universign::Document`.
 

--- a/README.md
+++ b/README.md
@@ -85,32 +85,47 @@ transaction = Universign::Transaction.new('9696179e-a43d-4803-beeb-9e5c02fd159b'
 transaction.signed?
 ```
 
-The gem also supports the updated way of creating multiple signature fields per document:
+The gem also supports the updated way of creating multiple fields per document:
 
-```ruby
-doc_1 = Universign::Document.new(
-  name:    'one.pdf',
-  content: File.open('spec/fixtures/universign-guide-8.8.pdf').read,
-  signature_fields: [
-    Universign::SignatureField.new(coordinate: [20, 20], page: 1, signer_index: 0),
-    Universign::SignatureField.new(coordinate: [80, 20], page: 1, signer_index: 0)
-  ]
-)
+- Multiple signatures
+  ```ruby
+  doc_1 = Universign::Document.new(
+    name:    'one.pdf',
+    content: File.open('spec/fixtures/universign-guide-8.8.pdf').read,
+    signature_fields: [
+      Universign::SignatureField.new(coordinate: [20, 20], page: 1, signer_index: 0),
+      Universign::SignatureField.new(coordinate: [80, 20], page: 1, signer_index: 0)
+    ]
+  )
 
-doc_2 = Universign::Document.new(
-  name:    'two.pdf',
-  content: File.open('spec/fixtures/universign-guide-8.8.pdf').read,
-  signature_fields: [
-    Universign::SignatureField.new(coordinate: [100, 120], page: 4, signer_index: 0),
-  ]
-)
+  doc_2 = Universign::Document.new(
+    name:    'two.pdf',
+    content: File.open('spec/fixtures/universign-guide-8.8.pdf').read,
+    signature_fields: [
+      Universign::SignatureField.new(coordinate: [100, 120], page: 4, signer_index: 0),
+    ]
+  )
 
-transaction = Universign::Transaction.create(
-  documents: [doc_1, doc_2],
-  signers:   [signer],
-  options:   { profile: 'default', final_doc_sent: true }
-)
-```
+  transaction = Universign::Transaction.create(
+    documents: [doc_1, doc_2],
+    signers:   [signer],
+    options:   { profile: 'default', final_doc_sent: true }
+  )
+  ```
+
+- Multiple checkboxes
+  ```ruby
+  Universign::Document.new(
+    name:    "one.pdf",
+    content: File.open("spec/fixtures/universign-guide-8.8.pdf").read,
+    check_box_texts: [
+      "My first checkbox text",
+      "My second checkbox text",
+      ""
+    ]
+  )
+  ```
+  Note that the last checkbox must be an empty string as requested in the official documentation.
 
 ### `Universign::Document`
 

--- a/lib/universign/document.rb
+++ b/lib/universign/document.rb
@@ -88,6 +88,19 @@ module Universign
       end
     end
 
+    def check_box_texts
+      @check_box_texts ||= params["checkBoxTexts"]
+    end
+
+    def check_box_texts=(data)
+      if !data.is_a?(Array)
+        raise "CheckBoxTextsMustBeAnArray"
+      end
+
+      @check_box_texts = data
+      params["checkBoxTexts"] = data
+    end
+
     # The meta data of the PDF document
     #
     # @return [Hash]

--- a/lib/universign/version.rb
+++ b/lib/universign/version.rb
@@ -1,3 +1,3 @@
 module Universign
-  VERSION = "1.5.2"
+  VERSION = "1.6.0"
 end

--- a/lib/universign/version.rb
+++ b/lib/universign/version.rb
@@ -1,3 +1,3 @@
 module Universign
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end


### PR DESCRIPTION
J'ai fait une carte spécifique pour ça -> [Trello](https://trello.com/c/AUGF892o/450-ajouter-des-checkboxs-sur-le-document-universign)
J'ai rajouté un tag `v1.5.2`

C'est testé en ne renseignant pas `check_box_texts` :
![Capture d’écran 2023-05-04 à 14 48 01](https://user-images.githubusercontent.com/65570378/236209139-44d72bce-ae68-4f66-8e02-81c117322734.png)

En en rajoutant 2 :
![Capture d’écran 2023-05-04 à 14 48 16](https://user-images.githubusercontent.com/65570378/236209181-ee821c8b-0a4b-4524-97cd-a577405d77da.png)
 