### PR TITLE
fix: parse signer_id from sign URL fragment

### DIFF
--- a/lib/universign/transaction.rb
+++ b/lib/universign/transaction.rb
@@ -49,14 +49,16 @@ module Universign
       @sign_url ||= data.dig("signerInfos", current_signer || 0, "url")
     end
 
-    # The signer id, parsed from the sign URL query param (?id=...).
+    # The signer id, parsed from the sign URL. Universign exposes the id in the
+    # query string on legacy URLs (".../signature/?id=...") and in the fragment
+    # on app.universign.com URLs (".../sig/#/?id=..."), so we read from both.
     #
     # @return [String, nil]
     def signer_id
-      query = URI(sign_url.to_s).query
-      return if query.nil?
+      params = URI(sign_url.to_s).then { |uri| uri.query || uri.fragment }
+      return if params.nil?
 
-      URI.decode_www_form(query).to_h["id"]
+      URI.decode_www_form(params.sub(%r{\A/?\??}, "")).to_h["id"]
     end
 
     # A list of beans containing information about the signers

--- a/spec/universign/transaction_spec.rb
+++ b/spec/universign/transaction_spec.rb
@@ -47,6 +47,14 @@ describe Universign::Transaction do
       expect(transaction.signer_id).to eq("signer-id")
     end
 
+    context "when Universign returns the id in the URL fragment" do
+      let(:sign_url) { "https://app.universign.com/sig/#/?id=signer-id" }
+
+      it "parses the signer_id from the fragment" do
+        expect(transaction.signer_id).to eq("signer-id")
+      end
+    end
+
     it "does not make an extra getTransactionInfo call" do
       expect(client).not_to receive(:call).with("requester.getTransactionInfo", anything)
 


### PR DESCRIPTION
## Problème

Universign renvoie désormais l'URL de signature avec l'`id` du signataire **dans le fragment** (`https://app.universign.com/sig/#/?id=...`) et non plus dans la query string.

`Transaction#signer_id` lisait uniquement `URI(sign_url).query`, qui est `nil` pour ces URLs → `signer_id` renvoyait `nil`. Les consommateurs (ex. Swissroc) ne pouvaient plus identifier le signataire : le flux de signature restait bloqué silencieusement (aucune exception levée).

## Correctif

`signer_id` lit l'`id` depuis la **query OU le fragment**, ce qui couvre les URLs legacy (`.../signature/?id=...`) et app.universign.com (`.../sig/#/?id=...`).

## Tests

- Nouveau test couvrant le format `app.universign.com` (id dans le fragment).
- Suite complète : 61 exemples, 0 échec, 100% de couverture (lignes + branches).